### PR TITLE
[Docs] : Swagger API 명세서 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
     runtimeOnly 'com.mysql:mysql-connector-j'
 }
 

--- a/src/main/java/usay/app/global/config/SwaggerConfig.java
+++ b/src/main/java/usay/app/global/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package usay.app.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@OpenAPIDefinition(
+		info = @Info(
+				title = "Usay API",
+				description = "SwaggerTest API Docs",
+				version = "v1"
+		))
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+	@Bean
+	public GroupedOpenApi chatOpenApi() {
+		String[] paths = {"/**"};
+
+		return GroupedOpenApi.builder()
+				.group("Usay API v1")
+				.pathsToMatch(paths)
+				.build();
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,13 +37,14 @@ spring:
 
 springdoc:
   api-docs:
+    path: /api-docs.json
     groups:
       enabled: true
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-  swagger-ui:
-    path: /
-    disable-swagger-default-url: true
+  swagger-ui: # Path : localhost:8080/swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,16 @@ spring:
     defer-datasource-initialization: true
     database-platform: org.hibernate.dialect.H2Dialect
 
+springdoc:
+  api-docs:
+    groups:
+      enabled: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /
+    disable-swagger-default-url: true
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#16 

## 📝 작업 내용

- Swagger 3 명세 페이지 작성 환경을 추가하였습니다.
  - Springdocs 의존성을 추가하였습니다.
  - security 제한은 추가하지 않았습니다. 

## 💬 후속 작업 및 논의사항
